### PR TITLE
Replace django importlib with python importlib

### DIFF
--- a/classymail/utils.py
+++ b/classymail/utils.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone, translation
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 class isolate_timezone(object):


### PR DESCRIPTION
Django 1.9 dropped django.utils.importlib and now
python importlib is available in Python 2.7 which
is a dependency of Django 1.7+

https://docs.python.org/2/library/importlib.html